### PR TITLE
chore: update claude hooks and settings

### DIFF
--- a/.claude/hooks/lint-article.sh
+++ b/.claude/hooks/lint-article.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-f=$(jq -r '.tool_input.file_path // .tool_response.filePath')
+INPUT=$(cat)
+f=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_response.filePath // ""')
 
 if [[ "$f" =~ /articles/.*\.md$ ]]; then
-  npx markdownlint-cli2 "$f" 2>&1
-  npx textlint "$f" 2>&1
+  RESULT=""
+  RESULT+=$(npx markdownlint-cli2 "$f" 2>&1 || true)
+  RESULT+=$'\n'
+  RESULT+=$(npx textlint "$f" 2>&1 || true)
+
+  TRIMMED=$(echo "$RESULT" | sed '/^$/d')
+  if [[ -n "$TRIMMED" ]]; then
+    jq -n --arg ctx "$TRIMMED" --arg msg "$TRIMMED" \
+      '{systemMessage: $msg, hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+  fi
 fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,11 @@
       "Bash(gh pr view:*)",
       "Bash(jq:*)",
       "Bash(npm run format:*)",
-      "Bash(npm run lint:*)"
+      "Bash(npm run lint:*)",
+      "Bash(pnpm format:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm markdownlint-cli2:*)",
+      "Bash(pnpm textlint:*)"
     ],
     "deny": ["Bash(git:*)", "Bash(npm install:*)", "Bash(npx:*)"]
   }


### PR DESCRIPTION
## Summary

記事のLint修正作業中に、hookスクリプトとpermission設定の不足に気づいたため修正した。

lint-article.shは標準入力の読み取りが欠落しており、markdownlintの結果も出力していなかった。また、pnpmコマンド（format、lint、markdownlint-cli2）のpermissionが未登録だったため、実行のたびに許可確認が発生していた。